### PR TITLE
TLS communication with Lets Encrypt and ACM

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2018 Bhavik Kumar
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -256,19 +256,6 @@ Resources:
         CidrIp:
           'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
 
-  HAProxyStatsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security group to allow HTTP/HTTPS traffic
-      VpcId:
-        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '1936'
-        ToPort: '1936'
-        CidrIp:
-          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
-
   InternalLoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -611,23 +598,6 @@ Resources:
         HttpCode: '200'
       Port: 443
       Protocol: HTTPS
-      UnhealthyThresholdCount: 4
-      VpcId:
-        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-
-  HAProxyStatsTargetGroup:
-    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
-    Properties:
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPath: /health
-      HealthCheckPort: 80
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 8
-      HealthyThresholdCount: 2
-      Matcher:
-        HttpCode: '200'
-      Port: 1936
-      Protocol: HTTP
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
@@ -1274,19 +1244,6 @@ Resources:
           'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
       SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
-  HAProxyStatsClusterListener:
-    DependsOn:
-      - HAProxyStatsTargetGroup
-      - InternalLoadBalancer
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
-    Properties:
-      DefaultActions:
-      - TargetGroupArn: !Ref HAProxyStatsTargetGroup
-        Type: forward
-      LoadBalancerArn: !Ref InternalLoadBalancer
-      Port: 1936
-      Protocol: HTTP
-
   PublicDNS:
     DependsOn:
       - ExternalLoadBalancer
@@ -1510,11 +1467,6 @@ Outputs:
     Value: !Ref HAProxySecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-HAProxySecurityGroup'
-  HAProxyStatsSecurityGroupOutput:
-    Description: The security group which allows HAProxy stats to function
-    Value: !Ref HAProxyStatsSecurityGroup
-    Export:
-      Name: !Sub '${AWS::StackName}-HAProxyStatsSecurityGroup'
   SwarmTableName:
     Description: The DynamoDB table name for the swarm cluster
     Value: !Ref SwarmDynamoDBTable
@@ -1569,12 +1521,7 @@ Outputs:
     Description: The HA Proxy target group
     Value: !Ref HAProxyHttpsTargetGroup
     Export:
-      Name: !Sub '${AWS::StackName}-HAProxyHttpsTargetGroup'      
-  HAProxyStatsTargetGroup:
-    Description: The HA Proxy stats target group
-    Value: !Ref HAProxyStatsTargetGroup
-    Export:
-      Name: !Sub '${AWS::StackName}-HAProxyStatsTargetGroup'
+      Name: !Sub '${AWS::StackName}-HAProxyHttpsTargetGroup'
 
 Mappings:
   # This list comes from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -914,7 +914,7 @@ Resources:
                     networks:
                       default_net:
                         aliases:
-                          - consulserver.{{DOMAIN}}
+                          - consulagent.{{DOMAIN}}
                     command: "consul agent -config-file /consul/config/config.json"
                     ports:
                       - target: 8500
@@ -1011,8 +1011,8 @@ Resources:
                     networks:
                       default_net:
                         aliases:
-                          - haproxy.server
-                    command: "-config=/tmp/haproxy.json -consul-addr=consulserver.{{DOMAIN}}:8500"
+                          - haproxy.{{DOMAIN}}
+                    command: "-config=/tmp/haproxy.json"
                     ports:
                       - target: 80
                         published: 80
@@ -1022,6 +1022,7 @@ Resources:
                         mode: host
                     volumes:
                       - /opt/haproxy:/tmp
+                      - /etc/letsencrypt:/certs:ro
                     deploy:
                       mode: global
                       endpoint_mode: dnsrr

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -337,6 +337,12 @@ Resources:
         FromPort: '80'
         ToPort: '80'
         CidrIp: 0.0.0.0/0
+        Description: 'Public API Traffic'
+      - IpProtocol: tcp
+        FromPort: '8200'
+        ToPort: '8200'
+        CidrIp: 0.0.0.0/0
+        Description: 'Public Vault UI Traffic'
 
   SwarmDynamoDBTable:
     Type: AWS::DynamoDB::Table
@@ -1158,6 +1164,23 @@ Resources:
           'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
       SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
+  VaultExternalHttpListener:
+    DependsOn:
+      - VaultTargetGroup
+      - ExternalLoadBalancer
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+      - TargetGroupArn: !Ref VaultTargetGroup
+        Type: forward
+      LoadBalancerArn: !Ref ExternalLoadBalancer
+      Port: 8200
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
+
   VaultClusterHttpListener:
     DependsOn:
       - VaultClusterTargetGroup
@@ -1200,6 +1223,19 @@ Resources:
       LoadBalancerArn: !Ref InternalLoadBalancer
       Port: 1936
       Protocol: HTTP
+
+  VaultPublicDNS:
+    DependsOn:
+      - ExternalLoadBalancer
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      Name: !Join [ '.', [ 'vault', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
+      Type: A
+      AliasTarget:
+        HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt ExternalLoadBalancer.DNSName
+      HostedZoneId:
+        'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-HostedZoneId'
 
   VaultPrivateDNS:
     DependsOn:

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -12,6 +12,7 @@ Metadata:
       - ParentPrivateZoneStack
       - ParentAlertStack
       - LogAggregatorStack
+      - CertificateStack
     - Label:
         default: 'Docker Swarm Manager Parameters'
       Parameters:
@@ -47,6 +48,9 @@ Parameters:
     Type: String
   LogAggregatorStack:
     Description: 'The log aggregator stack which was created using operations/fluentd-aggregator.yaml template'
+    Type: String
+  CertificateStack:
+    Description: 'The certificate stack which was created using operations/certificate-manager.yaml template'
     Type: String
   KeyName:
     Description: Amazon EC2 Key Pair
@@ -439,22 +443,31 @@ Resources:
       Roles:
         - !Ref SwarmManagerRole
 
-  # CertificateBucketPolicy:
-  #   DependsOn:
-  #     - SwarmManagerRole
-  #   Type: AWS::IAM::Policy
-  #   Properties:
-  #     PolicyName: "swarm-manager-certificate-download-policy"
-  #     PolicyDocument:
-  #       Version: "2012-10-17"
-  #       Statement:
-  #         -
-  #           Effect: "Allow"
-  #           Action:
-  #             - "s3:GetObject"
-  #           Resource: !Sub 'arn:aws:s3:::${CertificateS3Bucket}/*'
-  #     Roles:
-  #       - !Ref SwarmManagerRole
+  CertificateBucketPolicy:
+    DependsOn:
+      - SwarmManagerRole
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "certificate-download-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "s3:ListBucket"
+            Resource:
+            - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucketArn'
+          -
+            Effect: "Allow"
+            Action:
+              - s3:ListObjects
+              - "s3:GetObject"
+            Resource:
+            - !Join ["", [ 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucketArn', "/*" ] ]
+
+      Roles:
+        - !Ref SwarmManagerRole
 
   SwarmLifecycleQueue:
     Type: AWS::SQS::Queue
@@ -539,7 +552,7 @@ Resources:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /v1/sys/health
       HealthCheckPort: 8200
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 8
       HealthyThresholdCount: 2
       Matcher:
@@ -547,7 +560,7 @@ Resources:
       Name: !Join ['-', [ !Ref "AWS::StackName", Vault ] ]
       # This port should only be available internally.
       Port: 8200
-      Protocol: HTTP
+      Protocol: HTTPS
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
@@ -558,7 +571,7 @@ Resources:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /v1/sys/health
       HealthCheckPort: 8200
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 8
       HealthyThresholdCount: 2
       Matcher:
@@ -566,7 +579,7 @@ Resources:
       Name: !Join ['-', [ !Ref "AWS::StackName", VaultCluster ] ]
       # This port should only be available internally.
       Port: 8201
-      Protocol: HTTP
+      Protocol: HTTPS
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
@@ -610,13 +623,13 @@ Resources:
   SwarmManagerLaunchConfiguration:
     Metadata:
       Comment: Update, Install Docker and initialise the swarm
-      # AWS::CloudFormation::Authentication:
-      #   rolebased:
-      #     type: "S3"
-      #     buckets:
-      #       - !Ref CertificateS3Bucket
-      #     roleName:
-      #       Ref: SwarmManagerRole
+      AWS::CloudFormation::Authentication:
+        CertificateAccessCreds:
+          type: "S3"
+          buckets:
+            - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucket'
+          roleName:
+            Ref: SwarmManagerRole
       AWS::CloudFormation::Init:
         configSets:
           full_install:
@@ -626,13 +639,12 @@ Resources:
             - init_aws_swarm
             - swarm_node_healthcheck
             - guide_aws_swarm
-            # - certificates
+            - certificates
             - consul
             - vault
             - haproxy
           update_install:
             - install_cfn
-            # - certificates
         install_cfn:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -741,6 +753,34 @@ Resources:
           commands:
             run_fluentd:
               command: "docker run -d -h `hostname` -p 24224:24224 -p 5140:5140 --restart=always -e FLUENTD_CONF=fluentd.conf -v /data:/fluentd/log -v /etc/fluentd.conf:/fluentd/etc/fluentd.conf bhavikk/fluentd-sumologic:latest"
+              cwd: "~"
+        certificates:
+          files:
+            /tmp/letsencrypt.tar.gz:
+              source:
+                Fn::Join:
+                  - ""
+                  -
+                    - "https://"
+                    - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucket'
+                    - ".s3.amazonaws.com"
+                    - "/letsencrypt.tar.gz"
+              mode: "000644"
+              owner: "root"
+              group: "root"
+              authentication: "CertificateAccessCreds"
+          commands:
+            create_directory:
+              command: "mkdir -p /etc/letsencrypt"
+              cwd: "~"
+            extract_certificates:
+              command: "tar -zxf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt/"
+              cwd: "~"
+            fix_permissions_live:
+              command: "chmod 755 /etc/letsencrypt/live"
+              cwd: "~"
+            fix_permissions_archive:
+              command: "chmod 755 /etc/letsencrypt/archive"
               cwd: "~"
         init_aws_swarm:
           commands:
@@ -890,8 +930,12 @@ Resources:
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"
-                  tls_disable = 1
+                  tls_cert_file = "/certs/live/{{DOMAIN}}/fullchain.pem"
+                  tls_key_file = "/certs/live/{{DOMAIN}}/privkey.pem"
                 }
+              context:
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root
@@ -899,21 +943,15 @@ Resources:
             config_file_permission:
               command: "chmod 644 /opt/vault/vault.hcl"
             docker_run:
-              command: "docker run --log-driver=fluentd -d --name vault --net=host --restart=always -e 'VAULT_REDIRECT_INTERFACE=eth0' -e VAULT_CLUSTER_ADDR=$VAULT_CLUSTER_ADDR -v /opt/vault:/config --cap-add IPC_LOCK vault server -config=/config/vault.hcl"
+              command: "docker run --log-driver=fluentd -d --name vault --net=host --restart=always -e VAULT_API_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -e VAULT_CLUSTER_ADDR=$VAULT_CLUSTER_ADDR -v /etc/letsencrypt:/certs:ro -v /opt/vault:/config --cap-add IPC_LOCK vault server -config=/config/vault.hcl"
               env:
-                VAULT_CLUSTER_ADDR: { "Fn::Join" : [ "", [ "http://", { "Fn::GetAtt" : ["InternalLoadBalancer", "DNSName"] }, ":8201" ] ] }
+                VAULT_CLUSTER_ADDR: { "Fn::Join" : [ "", [ "https://", { "Fn::GetAtt" : ["InternalLoadBalancer", "DNSName"] }, ":8201" ] ] }
               cwd: "~"
             init_vault:
-              command: "docker run --log-driver=fluentd --restart=no -e DYNAMODB_TABLE=$DYNAMODB_TABLE -e 'VAULT_SCHEME=http' bhavikk/init-vault:latest"
+              command: "docker run --log-driver=fluentd --restart=no -e DYNAMODB_TABLE=$DYNAMODB_TABLE -e 'VAULT_SCHEME=https' -e 'VAULT_SKIP_VERIFY=true' bhavikk/init-vault:latest"
               env:
                 DYNAMODB_TABLE: { "Ref" : "VaultDynamoDBTable" }
               cwd: "~"
-        # certificates:
-        #   sources:
-        #     /opt/certificates: !Join ['', [ 'https://', { "Ref" : "CertificateS3Bucket" }, '.s3.amazonaws.com/', { "Ref" : "CertificateFileName" } ] ]
-        #   commands:
-        #     config_file_permission:
-        #       command: "chmod 400 /opt/certificates/*"
         haproxy:
           files:
             /opt/haproxy/compose.yaml:
@@ -1114,7 +1152,11 @@ Resources:
         Type: forward
       LoadBalancerArn: !Ref InternalLoadBalancer
       Port: 8200
-      Protocol: HTTP
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
   VaultClusterHttpListener:
     DependsOn:
@@ -1127,7 +1169,11 @@ Resources:
         Type: forward
       LoadBalancerArn: !Ref InternalLoadBalancer
       Port: 8201
-      Protocol: HTTP
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
   HAProxyHttpClusterListener:
     DependsOn:

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -948,7 +948,7 @@ Resources:
                 VAULT_CLUSTER_ADDR: { "Fn::Join" : [ "", [ "https://", { "Fn::GetAtt" : ["InternalLoadBalancer", "DNSName"] }, ":8201" ] ] }
               cwd: "~"
             init_vault:
-              command: "docker run --log-driver=fluentd --restart=no -e DYNAMODB_TABLE=$DYNAMODB_TABLE -e 'VAULT_SCHEME=https' -e 'VAULT_SKIP_VERIFY=true' bhavikk/init-vault:latest"
+              command: "docker run --log-driver=fluentd --restart=no -e DYNAMODB_TABLE=$DYNAMODB_TABLE -e VAULT_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -e VAULT_SKIP_VERIFY=true bhavikk/init-vault:latest"
               env:
                 DYNAMODB_TABLE: { "Ref" : "VaultDynamoDBTable" }
               cwd: "~"

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -987,7 +987,7 @@ Resources:
             config_file_permission:
               command: "chmod 644 /opt/vault/vault.hcl"
             docker_run:
-              command: "docker run --log-driver=fluentd -d --name vault --net=host --restart=always -e VAULT_API_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -e VAULT_CLUSTER_ADDR=$VAULT_CLUSTER_ADDR -v /etc/letsencrypt:/certs:ro -v /opt/vault:/config --cap-add IPC_LOCK vault server -config=/config/vault.hcl"
+              command: "docker run --log-driver=fluentd -d --name vault --net=host --restart=always -e VAULT_API_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -v /etc/letsencrypt:/certs:ro -v /opt/vault:/config --cap-add IPC_LOCK vault server -config=/config/vault.hcl"
               env:
                 VAULT_CLUSTER_ADDR: { "Fn::Join" : [ "", [ "https://", { "Fn::GetAtt" : ["InternalLoadBalancer", "DNSName"] }, ":8201" ] ] }
               cwd: "~"

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -964,11 +964,13 @@ Resources:
               content: !Sub |
                 ui = true
                 storage "consul" {
-                  address = "127.0.0.1:8500"
+                  address = "consul-server.{{DOMAIN}}:8500"
                   path = "vault/"
                   scheme="https"
-                  tls_skip_verify="true"
                   token="${ConsulACLMasterToken}"
+                  tls_cert_file = "/certs/live/{{DOMAIN}}/cert.pem"
+                  tls_key_file = "/certs/live/{{DOMAIN}}/privkey.pem"
+                  tls_ca_file = "/certs/live/{{DOMAIN}}/chain.pem"
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"
@@ -1051,6 +1053,7 @@ Resources:
               cwd: "~"
               ignoreErrors: true
     DependsOn:
+      - PrivateDNS
       - SwarmDynamoDBTable
       - VaultDynamoDBTable
       - SwarmManagerInstanceProfile
@@ -1328,6 +1331,11 @@ Resources:
         AliasTarget:
           HostedZoneId: !GetAtt InternalLoadBalancer.CanonicalHostedZoneID
           DNSName: !GetAtt InternalLoadBalancer.DNSName
+      - Name: !Join [ '.', [ 'consul-server', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
+        Type: A
+        TTL: 300
+        ResourceRecords:
+        - 127.0.0.1
       - Name: !Join [ '.', [ 'consul-agent', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
         Type: A
         TTL: 300

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -232,6 +232,11 @@ Resources:
         ToPort: '8200'
         CidrIp:
           'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
+      - IpProtocol: tcp
+        FromPort: '8201'
+        ToPort: '8201'
+        CidrIp:
+          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'          
 
   HAProxySecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -27,11 +27,6 @@ Metadata:
       - EncryptionToken
       - ConsulACLDataCenter
       - ConsulACLMasterToken
-    # - Label:
-    #     default: 'TLS Certificate Parameters'
-    #   Parameters:
-    #   - CertificateS3Bucket
-    #   - CertificateFileName
 
 Parameters:
   ParentVPCStack:
@@ -162,12 +157,6 @@ Parameters:
     NoEcho: true
     Description: 'Only used for servers in the acl_datacenter, allows operators to bootstrap the ACL system with a token that is well-known.'
     Type: String
-  # CertificateS3Bucket:
-  #   Description: 'Secure S3 Bucket which contains the required certificates'
-  #   Type: String
-  # CertificateFileName:
-  #   Description: 'Certificate file name, supported file extensions are tar, tar+gzip, tar+bz2 and zip.'
-  #   Type: String
 
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
@@ -179,19 +168,6 @@ Resources:
     Properties:
       DisplayName: 'Manager ASG Notifications'
       TopicName: 'SwarmManagerNotifications'
-
-  SwarmManagerSSHSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Allow SSH to the Docker Swarm Managers
-      VpcId:
-        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-      SecurityGroupIngress:
-      # Port 22 is temporary, we will never need it in the future.
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 0.0.0.0/0
 
   SwarmClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -1074,7 +1050,6 @@ Resources:
               cwd: "~"
               ignoreErrors: true
     DependsOn:
-      - SwarmManagerSSHSecurityGroup
       - SwarmDynamoDBTable
       - VaultDynamoDBTable
       - SwarmManagerInstanceProfile
@@ -1094,7 +1069,6 @@ Resources:
       IamInstanceProfile: !Ref SwarmManagerInstanceProfile
       KeyName: !Ref KeyName
       SecurityGroups:
-        - !Ref SwarmManagerSSHSecurityGroup
         - !Ref SwarmClusterSecurityGroup
         - !Ref ConsulClusterSecurityGroup
         - !Ref VaultClusterSecurityGroup
@@ -1335,7 +1309,6 @@ Resources:
           HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
           DNSName: !GetAtt ExternalLoadBalancer.DNSName
 
-
   PrivateDNS:
     DependsOn:
       - InternalLoadBalancer
@@ -1512,9 +1485,6 @@ Resources:
         Value: !GetAtt ExternalLoadBalancer.LoadBalancerFullName
 
 Outputs:
-  ManagerSecurityGroupID:
-    Description: SecurityGroup ID of the Swarm Manager
-    Value: !Ref SwarmManagerSSHSecurityGroup
   ManagerAsgNotificationTopic:
     Description: The ASG notification topic of managers being started or terminated.
     Value: !Ref SwarmManagerAsgNotification

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -342,7 +342,12 @@ Resources:
         FromPort: '8200'
         ToPort: '8200'
         CidrIp: 0.0.0.0/0
-        Description: 'Public Vault UI Traffic'
+        Description: 'Public Vault Traffic'
+      - IpProtocol: tcp
+        FromPort: '8500'
+        ToPort: '8500'
+        CidrIp: 0.0.0.0/0
+        Description: 'Public Consul Traffic'
 
   SwarmDynamoDBTable:
     Type: AWS::DynamoDB::Table
@@ -525,7 +530,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '204'
-      Name: !Join ['-', [ !Ref "AWS::StackName", NodeHealthCheck ] ]
       # This port should only be available internally.
       Port: 44444
       Protocol: HTTP
@@ -539,14 +543,30 @@ Resources:
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /v1/health/service/consul
       HealthCheckPort: 8500
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 8
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200'
-      Name: !Join ['-', [ !Ref "AWS::StackName", ConsulCluster ] ]
       Port: 8500
-      Protocol: HTTP
+      Protocol: HTTPS
+      UnhealthyThresholdCount: 4
+      VpcId:
+        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+
+  ConsulExternalTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /v1/health/service/consul
+      HealthCheckPort: 8500
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 8
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: '200'
+      Port: 8500
+      Protocol: HTTPS
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
@@ -562,7 +582,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200,429'
-      Name: !Join ['-', [ !Ref "AWS::StackName", Vault ] ]
       Port: 8200
       Protocol: HTTPS
       UnhealthyThresholdCount: 4
@@ -580,7 +599,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200,429'
-      Name: !Join ['-', [ !Ref "AWS::StackName", VaultExternal ] ]
       Port: 8200
       Protocol: HTTPS
       UnhealthyThresholdCount: 4
@@ -598,7 +616,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200,429'
-      Name: !Join ['-', [ !Ref "AWS::StackName", VaultCluster ] ]
       # This port should only be available internally.
       Port: 8201
       Protocol: HTTPS
@@ -617,7 +634,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200'
-      Name: !Join ['-', [ !Ref "AWS::StackName", HAProxyCluster ] ]
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 4
@@ -635,7 +651,6 @@ Resources:
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: '200'
-      Name: !Join ['-', [ !Ref "AWS::StackName", HAProxyStatsCluster ] ]
       Port: 1936
       Protocol: HTTP
       UnhealthyThresholdCount: 4
@@ -829,16 +844,24 @@ Resources:
             /opt/consul/config.json:
               content: !Sub |
                 {
-                  "advertise_addr" : "{{ GetInterfaceIP \"eth0\" }}",
-                  "bind_addr": "{{ GetInterfaceIP \"eth0\" }}",
+                  "advertise_addr" : "{{{ADVERTISE_ADRR}}}",
+                  "bind_addr": "{{{BIND_ADRR}}}",
                   "client_addr": "0.0.0.0",
+                  "cert_file": "/certs/live/{{DOMAIN}}/cert.pem",
+                  "key_file": "/certs/live/{{DOMAIN}}/privkey.pem",
+                  "ca_file": "/certs/live/{{DOMAIN}}/chain.pem",
+                  "verify_outgoing": true,
+                  "ports" : {
+                    "http": -1,
+                    "https": 8500
+                  },
                   "data_dir": "/consul/data",
                   "datacenter": "${AWS::Region}",
                   "leave_on_terminate" : true,
                   "retry_join" : [
-                    "consul.server"
+                    "consulserver.{{DOMAIN}}"
                   ],
-                  "server_name" : "server.${AWS::Region}.consul",
+                  "domain": "{{DOMAIN}}",
                   "skip_leave_on_interrupt" : true,
                   "bootstrap_expect": ${ManagerClusterSize},
                   "server" : true,
@@ -855,6 +878,11 @@ Resources:
                   "acl_master_token": "${ConsulACLMasterToken}",
                   "acl_agent_token": "${ConsulACLMasterToken}"
                 }
+              context:
+                ADVERTISE_ADRR: '{{ GetInterfaceIP \"eth0\" }}'
+                BIND_ADRR: '{{ GetInterfaceIP \"eth0\" }}'
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root
@@ -873,14 +901,22 @@ Resources:
                     networks:
                       default_net:
                         aliases:
-                          - consul.server
+                          - consulserver.{{DOMAIN}}
                     command: "consul agent -config-file /consul/config/config.json"
                     ports:
                       - target: 8500
                         published: 8500
                         mode: host
+                      - target: 8600
+                        published: 8600
+                        mode: host
+                      - target: 8600
+                        published: 8600
+                        protocol: udp
+                        mode: host
                     volumes:
                       - /opt/consul:/consul/config
+                      - /etc/letsencrypt:/certs:ro
                     deploy:
                       mode: global
                       endpoint_mode: dnsrr
@@ -902,14 +938,18 @@ Resources:
                     networks:
                       default_net:
                         aliases:
-                          - consul.server
+                          - consulserver.{{DOMAIN}}
                     command: "consul agent -config-file /consul/config/config.json"
                     ports:
                       - target: 8500
                         published: 8500
                         mode: host
+                      - target: 8600
+                        published: 8600
+                        mode: host
                     volumes:
                       - /opt/consul:/consul/config
+                      - /etc/letsencrypt:/certs:ro
                     deploy:
                       mode: global
                       endpoint_mode: dnsrr
@@ -924,6 +964,9 @@ Resources:
                       placement:
                         constraints:
                           - node.role == worker
+              context:
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root
@@ -947,7 +990,8 @@ Resources:
                 storage "consul" {
                   address = "127.0.0.1:8500"
                   path = "vault/"
-                  scheme="http"
+                  scheme="https"
+                  tls_skip_verify="true"
                   token="${ConsulACLMasterToken}"
                 }
                 listener "tcp" {
@@ -992,7 +1036,7 @@ Resources:
                       default_net:
                         aliases:
                           - haproxy.server
-                    command: "-config=/tmp/haproxy.json -consul-addr=consul.server:8500"
+                    command: "-config=/tmp/haproxy.json -consul-addr=consulserver.{{DOMAIN}}:8500"
                     ports:
                       - target: 80
                         published: 80
@@ -1016,6 +1060,9 @@ Resources:
                       placement:
                         constraints:
                           - node.role == worker
+              context:
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root
@@ -1066,6 +1113,7 @@ Resources:
       - SwarmManagerLaunchConfiguration
       - SwarmHealthCheckTargetGroup
       - ConsulTargetGroup
+      - ConsulExternalTargetGroup
       - VaultTargetGroup
       - VaultClusterTargetGroup
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -1091,6 +1139,7 @@ Resources:
       TargetGroupARNs:
         - !Ref SwarmHealthCheckTargetGroup
         - !Ref ConsulTargetGroup
+        - !Ref ConsulExternalTargetGroup
         - !Ref VaultTargetGroup
         - !Ref VaultExternalTargetGroup
         - !Ref VaultClusterTargetGroup
@@ -1162,7 +1211,28 @@ Resources:
         Type: forward
       LoadBalancerArn: !Ref InternalLoadBalancer
       Port: 8500
-      Protocol: HTTP
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
+
+  ConsulUiExternalHttpListener:
+    DependsOn:
+      - ConsulExternalTargetGroup
+      - ExternalLoadBalancer
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+      - TargetGroupArn: !Ref ConsulExternalTargetGroup
+        Type: forward
+      LoadBalancerArn: !Ref ExternalLoadBalancer
+      Port: 8500
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
   VaultHttpListener:
     DependsOn:
@@ -1241,6 +1311,19 @@ Resources:
       Port: 1936
       Protocol: HTTP
 
+  ConsulPublicDNS:
+    DependsOn:
+      - ExternalLoadBalancer
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      Name: !Join [ '.', [ 'consul', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
+      Type: A
+      AliasTarget:
+        HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt ExternalLoadBalancer.DNSName
+      HostedZoneId:
+        'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-HostedZoneId'
+
   VaultPublicDNS:
     DependsOn:
       - ExternalLoadBalancer
@@ -1267,7 +1350,7 @@ Resources:
       HostedZoneId:
         'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-HostedZoneId'
 
-  APIDNS:
+  APIPublicDNS:
     DependsOn:
       - ExternalLoadBalancer
     Type: 'AWS::Route53::RecordSet'

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -232,11 +232,6 @@ Resources:
         ToPort: '8200'
         CidrIp:
           'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
-      - IpProtocol: tcp
-        FromPort: '8201'
-        ToPort: '8201'
-        CidrIp:
-          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
 
   HAProxySecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -284,11 +279,6 @@ Resources:
       - IpProtocol: tcp
         FromPort: '8200'
         ToPort: '8200'
-        CidrIp:
-          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
-      - IpProtocol: tcp
-        FromPort: '8201'
-        ToPort: '8201'
         CidrIp:
           'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
       - IpProtocol: tcp
@@ -576,24 +566,6 @@ Resources:
       Matcher:
         HttpCode: '200,429'
       Port: 8200
-      Protocol: HTTPS
-      UnhealthyThresholdCount: 4
-      VpcId:
-        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
-
-  VaultClusterTargetGroup:
-    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
-    Properties:
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPath: /v1/sys/health
-      HealthCheckPort: 8200
-      HealthCheckProtocol: HTTPS
-      HealthCheckTimeoutSeconds: 8
-      HealthyThresholdCount: 2
-      Matcher:
-        HttpCode: '200,429'
-      # This port should only be available internally.
-      Port: 8201
       Protocol: HTTPS
       UnhealthyThresholdCount: 4
       VpcId:
@@ -988,8 +960,6 @@ Resources:
               command: "chmod 644 /opt/vault/vault.hcl"
             docker_run:
               command: "docker run --log-driver=fluentd -d --name vault --net=host --restart=always -e VAULT_API_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -v /etc/letsencrypt:/certs:ro -v /opt/vault:/config --cap-add IPC_LOCK vault server -config=/config/vault.hcl"
-              env:
-                VAULT_CLUSTER_ADDR: { "Fn::Join" : [ "", [ "https://", { "Fn::GetAtt" : ["InternalLoadBalancer", "DNSName"] }, ":8201" ] ] }
               cwd: "~"
             init_vault:
               command: "docker run --log-driver=fluentd --restart=no -e DYNAMODB_TABLE=$DYNAMODB_TABLE -e VAULT_ADDR=https://`curl http://169.254.169.254/latest/meta-data/local-ipv4`:8200 -e VAULT_SKIP_VERIFY=true bhavikk/init-vault:latest"
@@ -1093,7 +1063,6 @@ Resources:
       - ConsulTargetGroup
       - ConsulExternalTargetGroup
       - VaultTargetGroup
-      - VaultClusterTargetGroup
     Type: AWS::AutoScaling::AutoScalingGroup
     CreationPolicy:
       ResourceSignal:
@@ -1120,7 +1089,6 @@ Resources:
         - !Ref ConsulExternalTargetGroup
         - !Ref VaultTargetGroup
         - !Ref VaultExternalTargetGroup
-        - !Ref VaultClusterTargetGroup
       VPCZoneIdentifier:
         - !Select [0, !Split [",", "Fn::ImportValue": !Sub "${ParentVPCStack}-SubnetsPublic"] ]
         - !Select [1, !Split [",", "Fn::ImportValue": !Sub "${ParentVPCStack}-SubnetsPublic"] ]
@@ -1240,23 +1208,6 @@ Resources:
         Type: forward
       LoadBalancerArn: !Ref ExternalLoadBalancer
       Port: 8200
-      Protocol: HTTPS
-      Certificates:
-      - CertificateArn:
-          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
-      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
-
-  VaultClusterHttpListener:
-    DependsOn:
-      - VaultClusterTargetGroup
-      - InternalLoadBalancer
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
-    Properties:
-      DefaultActions:
-      - TargetGroupArn: !Ref VaultClusterTargetGroup
-        Type: forward
-      LoadBalancerArn: !Ref InternalLoadBalancer
-      Port: 8201
       Protocol: HTTPS
       Certificates:
       - CertificateArn:

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -545,7 +545,6 @@ Resources:
       Matcher:
         HttpCode: '200'
       Name: !Join ['-', [ !Ref "AWS::StackName", ConsulCluster ] ]
-      # This port should only be available internally.
       Port: 8500
       Protocol: HTTP
       UnhealthyThresholdCount: 4
@@ -564,7 +563,24 @@ Resources:
       Matcher:
         HttpCode: '200,429'
       Name: !Join ['-', [ !Ref "AWS::StackName", Vault ] ]
-      # This port should only be available internally.
+      Port: 8200
+      Protocol: HTTPS
+      UnhealthyThresholdCount: 4
+      VpcId:
+        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+
+  VaultExternalTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /v1/sys/health
+      HealthCheckPort: 8200
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 8
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: '200,429'
+      Name: !Join ['-', [ !Ref "AWS::StackName", VaultExternal ] ]
       Port: 8200
       Protocol: HTTPS
       UnhealthyThresholdCount: 4
@@ -1076,6 +1092,7 @@ Resources:
         - !Ref SwarmHealthCheckTargetGroup
         - !Ref ConsulTargetGroup
         - !Ref VaultTargetGroup
+        - !Ref VaultExternalTargetGroup
         - !Ref VaultClusterTargetGroup
       VPCZoneIdentifier:
         - !Select [0, !Split [",", "Fn::ImportValue": !Sub "${ParentVPCStack}-SubnetsPublic"] ]
@@ -1166,12 +1183,12 @@ Resources:
 
   VaultExternalHttpListener:
     DependsOn:
-      - VaultTargetGroup
+      - VaultExternalTargetGroup
       - ExternalLoadBalancer
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
-      - TargetGroupArn: !Ref VaultTargetGroup
+      - TargetGroupArn: !Ref VaultExternalTargetGroup
         Type: forward
       LoadBalancerArn: !Ref ExternalLoadBalancer
       Port: 8200

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -795,7 +795,7 @@ Resources:
                   "advertise_addr" : "{{{ADVERTISE_ADRR}}}",
                   "bind_addr": "{{{BIND_ADRR}}}",
                   "client_addr": "0.0.0.0",
-                  "cert_file": "/certs/live/{{DOMAIN}}/cert.pem",
+                  "cert_file": "/certs/live/{{DOMAIN}}/fullchain.pem",
                   "key_file": "/certs/live/{{DOMAIN}}/privkey.pem",
                   "ca_file": "/certs/live/{{DOMAIN}}/chain.pem",
                   "verify_outgoing": true,
@@ -940,7 +940,7 @@ Resources:
                   path = "vault/"
                   scheme="https"
                   token="${ConsulACLMasterToken}"
-                  tls_cert_file = "/certs/live/{{DOMAIN}}/cert.pem"
+                  tls_cert_file = "/certs/live/{{DOMAIN}}/fullchain.pem"
                   tls_key_file = "/certs/live/{{DOMAIN}}/privkey.pem"
                   tls_ca_file = "/certs/live/{{DOMAIN}}/chain.pem"
                 }

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -236,7 +236,7 @@ Resources:
         FromPort: '8201'
         ToPort: '8201'
         CidrIp:
-          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'          
+          'Fn::ImportValue': !Sub '${ParentVPCStack}-CidrBlock'
 
   HAProxySecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -309,6 +309,11 @@ Resources:
         ToPort: '80'
         CidrIp: 0.0.0.0/0
         Description: 'Public API Traffic'
+      - IpProtocol: tcp
+        FromPort: '443'
+        ToPort: '443'
+        CidrIp: 0.0.0.0/0
+        Description: 'Secure Public API Traffic'
       - IpProtocol: tcp
         FromPort: '8200'
         ToPort: '8200'
@@ -589,6 +594,23 @@ Resources:
         HttpCode: '200'
       Port: 80
       Protocol: HTTP
+      UnhealthyThresholdCount: 4
+      VpcId:
+        'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+
+  HAProxyHttpsTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /health
+      HealthCheckPort: 443
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 8
+      HealthyThresholdCount: 2
+      Matcher:
+        HttpCode: '200'
+      Port: 443
+      Protocol: HTTPS
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
@@ -994,6 +1016,9 @@ Resources:
                       - target: 80
                         published: 80
                         mode: host
+                      - target: 443
+                        published: 443
+                        mode: host
                       - target: 1936
                         published: 1936
                         mode: host
@@ -1231,6 +1256,23 @@ Resources:
       LoadBalancerArn: !Ref ExternalLoadBalancer
       Port: 80
       Protocol: HTTP
+
+  HAProxyHttpsClusterListener:
+    DependsOn:
+      - HAProxyHttpsTargetGroup
+      - ExternalLoadBalancer
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+      - TargetGroupArn: !Ref HAProxyHttpsTargetGroup
+        Type: forward
+      LoadBalancerArn: !Ref ExternalLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn:
+          'Fn::ImportValue': !Sub '${CertificateStack}-CertificateArn'
+      SslPolicy: 'ELBSecurityPolicy-TLS-1-2-2017-01'
 
   HAProxyStatsClusterListener:
     DependsOn:
@@ -1523,6 +1565,11 @@ Outputs:
     Value: !Ref HAProxyHttpTargetGroup
     Export:
       Name: !Sub '${AWS::StackName}-HAProxyHttpTargetGroup'
+  HAProxyHttpsTargetGroup:
+    Description: The HA Proxy target group
+    Value: !Ref HAProxyHttpsTargetGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-HAProxyHttpsTargetGroup'      
   HAProxyStatsTargetGroup:
     Description: The HA Proxy stats target group
     Value: !Ref HAProxyStatsTargetGroup

--- a/docker-swarm-cluster/swarm-manager-cluster.yaml
+++ b/docker-swarm-cluster/swarm-manager-cluster.yaml
@@ -1311,57 +1311,54 @@ Resources:
       Port: 1936
       Protocol: HTTP
 
-  ConsulPublicDNS:
+  PublicDNS:
     DependsOn:
       - ExternalLoadBalancer
-    Type: 'AWS::Route53::RecordSet'
+    Type: 'AWS::Route53::RecordSetGroup'
     Properties:
-      Name: !Join [ '.', [ 'consul', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
-        DNSName: !GetAtt ExternalLoadBalancer.DNSName
       HostedZoneId:
         'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-HostedZoneId'
+      RecordSets:
+      - Name: !Join [ '.', [ 'consul', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt ExternalLoadBalancer.DNSName
+      - Name: !Join [ '.', [ 'vault', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt ExternalLoadBalancer.DNSName
+      - Name: !Join [ '.', [ 'api', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt ExternalLoadBalancer.DNSName
 
-  VaultPublicDNS:
-    DependsOn:
-      - ExternalLoadBalancer
-    Type: 'AWS::Route53::RecordSet'
-    Properties:
-      Name: !Join [ '.', [ 'vault', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
-        DNSName: !GetAtt ExternalLoadBalancer.DNSName
-      HostedZoneId:
-        'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-HostedZoneId'
 
-  VaultPrivateDNS:
+  PrivateDNS:
     DependsOn:
       - InternalLoadBalancer
-    Type: 'AWS::Route53::RecordSet'
+    Type: 'AWS::Route53::RecordSetGroup'
     Properties:
-      Name: !Join [ '.', [ 'vault', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt InternalLoadBalancer.CanonicalHostedZoneID
-        DNSName: !GetAtt InternalLoadBalancer.DNSName
       HostedZoneId:
         'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-HostedZoneId'
-
-  APIPublicDNS:
-    DependsOn:
-      - ExternalLoadBalancer
-    Type: 'AWS::Route53::RecordSet'
-    Properties:
-      Name: !Join [ '.', [ 'api', 'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName' ] ]
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt ExternalLoadBalancer.CanonicalHostedZoneID
-        DNSName: !GetAtt ExternalLoadBalancer.DNSName
-      HostedZoneId:
-        'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-HostedZoneId'
+      RecordSets:
+      - Name: !Join [ '.', [ 'consul', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt InternalLoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt InternalLoadBalancer.DNSName
+      - Name: !Join [ '.', [ 'vault', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt InternalLoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt InternalLoadBalancer.DNSName
+      - Name: !Join [ '.', [ 'consul-agent', 'Fn::ImportValue': !Sub '${ParentPrivateZoneStack}-DomainName' ] ]
+        Type: A
+        TTL: 300
+        ResourceRecords:
+        - 172.18.0.1
 
   SwarmManagerLifecycleHook:
     DependsOn:

--- a/docker-swarm-cluster/swarm-worker-cluster.yaml
+++ b/docker-swarm-cluster/swarm-worker-cluster.yaml
@@ -601,8 +601,6 @@ Resources:
       SecurityGroups:
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-SwarmClusterSecurityGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-ConsulClusterSecurityGroup'
-        - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-ConsulClusterSecurityGroup'
-        - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-ConsulClusterSecurityGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-HAProxySecurityGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-HAProxyStatsSecurityGroup'
       UserData:

--- a/docker-swarm-cluster/swarm-worker-cluster.yaml
+++ b/docker-swarm-cluster/swarm-worker-cluster.yaml
@@ -497,12 +497,26 @@ Resources:
         haproxy_config:
           files:
             /opt/haproxy/haproxy.json:
-              content:
+              content: !Sub |
+                consul {
+                  address = "consul-agent.{{DOMAIN}}:8500"
+                  token = "${ConsulACLAgentToken}"
+
+                  ssl {
+                    enabled = true
+                    cert = "/certs/live/{{DOMAIN}}/cert.pem"
+                    key  = "/certs/live/{{DOMAIN}}/privkey.pem"
+                    ca_cert = "/certs/live/{{DOMAIN}}/chain.pem"
+                  }
+                }
                 template {
                   source = "/tmp/haproxy.ctmpl"
                   destination = "/etc/haproxy/haproxy.cfg"
                   command = "/bin/sh -c 'haproxy -D -f /etc/haproxy/haproxy.cfg -p /run/haproxy-lb.pid -sf $(cat /run/haproxy-lb.pid)'"
                 }
+              context:
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root

--- a/docker-swarm-cluster/swarm-worker-cluster.yaml
+++ b/docker-swarm-cluster/swarm-worker-cluster.yaml
@@ -8,9 +8,11 @@ Metadata:
         default: 'Parent Stacks'
       Parameters:
       - ParentVPCStack
+      - ParentPublicZoneStack
       - ParentAlertStack
       - SwarmManagerStack
       - LogAggregatorStack
+      - CertificateStack
     - Label:
         default: 'Docker Swarm Worker Parameters'
       Parameters:
@@ -25,11 +27,6 @@ Metadata:
       - EncryptionToken
       - ConsulACLDataCenter
       - ConsulACLAgentToken
-    # - Label:
-    #     default: 'TLS Certificate Parameters'
-    #   Parameters:
-    #   - CertificateS3Bucket
-    #   - CertificateFileName
     - Label:
         default: 'HA Proxy Parameters'
       Parameters:
@@ -39,6 +36,9 @@ Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
     Type: String
+  ParentPublicZoneStack:
+    Description: 'Stack name of parent Hosted Zone stack based on dns/*-hosted-zone.yaml template.'
+    Type: String    
   ParentAlertStack:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
     Type: String
@@ -47,6 +47,9 @@ Parameters:
     Type: String
   LogAggregatorStack:
     Description: 'The log aggregator stack which was created using operations/fluentd-aggregator.yaml template'
+    Type: String
+  CertificateStack:
+    Description: 'The certificate stack which was created using operations/certificate-manager.yaml template'
     Type: String
   DesiredWorkerClusterSize:
     Description: The desired number of swarm worker nodes
@@ -207,8 +210,7 @@ Resources:
             Action:
               - "dynamodb:GetItem"
             Resource:
-              Fn::ImportValue:
-                !Sub "${SwarmManagerStack}-SwarmTableArn"
+            - 'Fn::ImportValue': !Sub "${SwarmManagerStack}-SwarmTableArn"
       Roles:
         - !Ref SwarmWorkerRole
 
@@ -231,22 +233,31 @@ Resources:
       Roles:
         - !Ref SwarmWorkerRole
 
-  # CertificateBucketPolicy:
-  #   DependsOn:
-  #     - SwarmWorkerRole
-  #   Type: AWS::IAM::Policy
-  #   Properties:
-  #     PolicyName: "swarm-worker-certificate-download-policy"
-  #     PolicyDocument:
-  #       Version: "2012-10-17"
-  #       Statement:
-  #         -
-  #           Effect: "Allow"
-  #           Action:
-  #             - "s3:GetObject"
-  #           Resource: !Sub 'arn:aws:s3:::${CertificateS3Bucket}/*'
-  #     Roles:
-  #       - !Ref SwarmWorkerRole
+  CertificateBucketPolicy:
+    DependsOn:
+      - SwarmWorkerRole
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: "certificate-download-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action:
+              - "s3:ListBucket"
+            Resource:
+            - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucketArn'
+          -
+            Effect: "Allow"
+            Action:
+              - s3:ListObjects
+              - "s3:GetObject"
+            Resource:
+            - !Join ["", [ 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucketArn', "/*" ] ]
+
+      Roles:
+        - !Ref SwarmWorkerRole
 
   SwarmLifecycleQueuePolicy:
     DependsOn:
@@ -281,27 +292,26 @@ Resources:
   SwarmWorkerLaunchConfiguration:
     Metadata:
       Comment: Update, Install Docker and initialise the swarm
-      # AWS::CloudFormation::Authentication:
-      #   rolebased:
-      #     type: "S3"
-      #     buckets:
-      #       - !Ref CertificateS3Bucket
-      #     roleName:
-      #       Ref: SwarmWorkerRole
+      AWS::CloudFormation::Authentication:
+        CertificateAccessCreds:
+          type: "S3"
+          buckets:
+            - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucket'
+          roleName:
+            Ref: SwarmWorkerRole
       AWS::CloudFormation::Init:
         configSets:
           full_install:
             - install_cfn
             - install_docker
             - setup_logging
-            # - certificates
+            - certificates
             - consul_config
             - haproxy_config
             - init_aws_swarm
             - swarm_node_healthcheck
           update_install:
             - install_cfn
-            # - certificates
         install_cfn:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -411,27 +421,57 @@ Resources:
             run_fluentd:
               command: "docker run -d -h `hostname` -p 24224:24224 -p 5140:5140 --restart=always -e FLUENTD_CONF=fluentd.conf -v /data:/fluentd/log -v /etc/fluentd.conf:/fluentd/etc/fluentd.conf bhavikk/fluentd-sumologic:latest"
               cwd: "~"
-        # certificates:
-        #   sources:
-        #     /opt/certificates: !Join ['', [ 'https://', { "Ref" : "CertificateS3Bucket" }, '.s3.amazonaws.com/', { "Ref" : "CertificateFileName" } ] ]
-        #   commands:
-        #     config_file_permission:
-        #       command: "chmod 400 /opt/certificates/*"
+        certificates:
+          files:
+            /tmp/letsencrypt.tar.gz:
+              source:
+                Fn::Join:
+                  - ""
+                  -
+                    - "https://"
+                    - 'Fn::ImportValue': !Sub '${CertificateStack}-CertificateBucket'
+                    - ".s3.amazonaws.com"
+                    - "/letsencrypt.tar.gz"
+              mode: "000644"
+              owner: "root"
+              group: "root"
+              authentication: "CertificateAccessCreds"
+          commands:
+            create_directory:
+              command: "mkdir -p /etc/letsencrypt"
+              cwd: "~"
+            extract_certificates:
+              command: "tar -zxf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt/"
+              cwd: "~"
+            fix_permissions_live:
+              command: "chmod 755 /etc/letsencrypt/live"
+              cwd: "~"
+            fix_permissions_archive:
+              command: "chmod 755 /etc/letsencrypt/archive"
+              cwd: "~"
         consul_config:
           files:
             /opt/consul/config.json:
               content: !Sub |
                 {
-                  "advertise_addr" : "{{ GetInterfaceIP \"eth0\" }}",
-                  "bind_addr": "{{ GetInterfaceIP \"eth0\" }}",
+                  "advertise_addr" : "{{{ADVERTISE_ADRR}}}",
+                  "bind_addr": "{{{BIND_ADRR}}}",
                   "client_addr": "0.0.0.0",
+                  "cert_file": "/certs/live/{{DOMAIN}}/cert.pem",
+                  "key_file": "/certs/live/{{DOMAIN}}/privkey.pem",
+                  "ca_file": "/certs/live/{{DOMAIN}}/chain.pem",
+                  "verify_outgoing": true,
+                  "ports" : {
+                    "http": -1,
+                    "https": 8500
+                  },
                   "data_dir": "/consul/data",
                   "datacenter": "${AWS::Region}",
                   "leave_on_terminate" : true,
                   "retry_join" : [
-                    "consul.server"
+                    "consulserver.{{DOMAIN}}"
                   ],
-                  "server_name" : "agent.${AWS::Region}.consul",
+                  "domain": "{{DOMAIN}}",
                   "skip_leave_on_interrupt" : false,
                   "server" : false,
                   "ui" : false,
@@ -443,6 +483,11 @@ Resources:
                   "acl_down_policy": "extend-cache",
                   "acl_agent_token": "${ConsulACLAgentToken}"
                 }
+              context:
+                ADVERTISE_ADRR: '{{ GetInterfaceIP \"eth0\" }}'
+                BIND_ADRR: '{{ GetInterfaceIP \"eth0\" }}'
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root

--- a/docker-swarm-cluster/swarm-worker-cluster.yaml
+++ b/docker-swarm-cluster/swarm-worker-cluster.yaml
@@ -457,7 +457,7 @@ Resources:
                   "advertise_addr" : "{{{ADVERTISE_ADRR}}}",
                   "bind_addr": "{{{BIND_ADRR}}}",
                   "client_addr": "0.0.0.0",
-                  "cert_file": "/certs/live/{{DOMAIN}}/cert.pem",
+                  "cert_file": "/certs/live/{{DOMAIN}}/fullchain.pem",
                   "key_file": "/certs/live/{{DOMAIN}}/privkey.pem",
                   "ca_file": "/certs/live/{{DOMAIN}}/chain.pem",
                   "verify_outgoing": true,
@@ -504,7 +504,7 @@ Resources:
 
                   ssl {
                     enabled = true
-                    cert = "/certs/live/{{DOMAIN}}/cert.pem"
+                    cert = "/certs/live/{{DOMAIN}}/fullchain.pem"
                     key  = "/certs/live/{{DOMAIN}}/privkey.pem"
                     ca_cert = "/certs/live/{{DOMAIN}}/chain.pem"
                   }

--- a/docker-swarm-cluster/swarm-worker-cluster.yaml
+++ b/docker-swarm-cluster/swarm-worker-cluster.yaml
@@ -38,7 +38,7 @@ Parameters:
     Type: String
   ParentPublicZoneStack:
     Description: 'Stack name of parent Hosted Zone stack based on dns/*-hosted-zone.yaml template.'
-    Type: String    
+    Type: String
   ParentAlertStack:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
     Type: String
@@ -522,17 +522,20 @@ Resources:
               group: root
             /opt/haproxy/haproxy.ctmpl:
               content: !Sub |
+                {{=<% %>=}}
                 global
                     log 127.0.0.1   local0
                     log 127.0.0.1   local1 notice
-                    debug
                     stats timeout 30s
                     maxconn 1024
+                    ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+                    ssl-default-bind-options no-sslv3 no-tls-tickets no-tlsv10 no-tlsv11
 
                 defaults
                     log global
                     option httplog
                     option dontlognull
+                    option forwardfor
                     mode http
                     timeout connect 5000
                     timeout client  50000
@@ -540,11 +543,24 @@ Resources:
 
                 frontend http-in
                     bind 0.0.0.0:80
-                    monitor-uri /health{{ range $i, $service := services }}{{ range $tag := .Tags }}{{ if $tag | regexMatch "^version=.+" }}{{ $version := index (. | split "=") 1 }}{{ if $service.Tags | contains "edge" }}
+                    monitor-uri /health
+                    redirect scheme https code 301 if !{ ssl_fc }
+
+                frontend https-in
+                    http-response set-header Strict-Transport-Security max-age=31536000;\ includeSubdomains;\ preload
+                    http-response set-header X-Frame-Options DENY
+                    http-response set-header X-Content-Type-Options nosniff
+                    bind 0.0.0.0:443 ssl crt /certs/live/<% DOMAIN %>/haproxy.pem
+                    monitor-uri /health
+                    # Add X-Headers necessary for HTTPS
+                    http-request set-header X-Forwarded-Host %[req.hdr(Host)]
+                    http-request set-header X-Forwarded-Proto https
+                    {{ range $i, $service := services }}{{ range $tag := .Tags }}{{ if $tag | regexMatch "^version=.+" }}{{ $version := index (. | split "=") 1 }}{{ if $service.Tags | contains "edge" }}
                     # Edge for {{ $service.Name }}, Version: {{ $version }}
                     acl {{ $service.Name }}{{ $version }} path_beg /v{{ $version }}/{{ $service.Name }}
                     use_backend {{ $service.Name }}{{ $version }} if {{ $service.Name }}{{ $version }}
                     {{ end }}{{ end }}{{ end }}{{ end }}
+                    default_backend nomatch
 
                 {{ range $i, $service := services }}{{ range $tag := .Tags }}{{ if $tag | regexMatch "^version=.+" }}{{ $version := index (. | split "=") 1 }}{{ if $service.Tags | contains "edge" }}
                 # Backend for {{ $service.Name }}, Version: {{ $version }}
@@ -559,12 +575,18 @@ Resources:
                     server {{.Address}} {{.Address}}:{{.Port}} check
                     {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
+                backend nomatch
+                    http-request deny deny_status 403
+
                 listen stats
                     bind 0.0.0.0:1936
                     stats enable
                     stats uri /
                     stats hide-version
                     stats auth admin:${HAProxyPassword}
+              context:
+                DOMAIN:
+                  'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
               mode: '000755'
               owner: root
               group: root
@@ -640,6 +662,7 @@ Resources:
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-SwarmHealthCheckTargetGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-ConsulTargetGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-HAProxyHttpTargetGroup'
+        - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-HAProxyHttpsTargetGroup'
         - 'Fn::ImportValue': !Sub '${SwarmManagerStack}-HAProxyStatsTargetGroup'
       VPCZoneIdentifier:
         - !Select [0, !Split [",", "Fn::ImportValue": !Sub "${ParentVPCStack}-SubnetsPublic"] ]

--- a/operations/certificate-manager.yaml
+++ b/operations/certificate-manager.yaml
@@ -291,24 +291,29 @@ Resources:
       InstanceType: "t2.nano"
       IamInstanceProfile: !Ref CertificateManagerInstanceProfile
       UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash -xe
-          yum update -y
-          # Check if the lets encrypt tarball exists, then we download and extract it.
-          mkdir -p /etc/letsencrypt
-          EXISTS=$(aws s3 ls s3://${CertificateBucket}/letsencrypt.tar.gz) || true
-          if [ ! -z "$EXISTS" ]; then
-            aws s3 cp s3://${CertificateBucket}/letsencrypt.tar.gz /tmp/letsencrypt.tar.gz
-            tar -zxf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt/
-          fi
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource CertBotLaunchConfiguration --configsets full_install --region ${AWS::Region}
-          # If the files were updated then we push the new certificates to the S3 bucket.
-          MODIFY_COUNT=$(find /etc/letsencrypt/ -type f -mmin -15 | wc -l)
-          if [ $MODIFY_COUNT -gt "0" ]; then
-            tar -zcf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt .
-            aws s3 cp /tmp/letsencrypt.tar.gz s3://${CertificateBucket}/ --sse
-          fi
-          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource CertBotAutoScaleGroup --region ${AWS::Region}
+        Fn::Base64:
+          !Sub
+          - |
+            #!/bin/bash -xe
+            yum update -y
+            # Check if the lets encrypt tarball exists, then we download and extract it.
+            mkdir -p /etc/letsencrypt
+            EXISTS=$(aws s3 ls s3://${CertificateBucket}/letsencrypt.tar.gz) || true
+            if [ ! -z "$EXISTS" ]; then
+              aws s3 cp s3://${CertificateBucket}/letsencrypt.tar.gz /tmp/letsencrypt.tar.gz
+              tar -zxf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt/
+            fi
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource CertBotLaunchConfiguration --configsets full_install --region ${AWS::Region}
+            # If the files were updated then we push the new certificates to the S3 bucket.
+            MODIFY_COUNT=$(find /etc/letsencrypt/ -type f -mmin -15 | wc -l)
+            if [ $MODIFY_COUNT -gt "0" ]; then
+              bash -c 'cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem /etc/letsencrypt/live/${DOMAIN}/privkey.pem > /etc/letsencrypt/live/${DOMAIN}/haproxy.pem'
+              tar -zcf /tmp/letsencrypt.tar.gz -C /etc/letsencrypt .
+              aws s3 cp /tmp/letsencrypt.tar.gz s3://${CertificateBucket}/ --sse
+            fi
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource CertBotAutoScaleGroup --region ${AWS::Region}
+          - DOMAIN:
+              'Fn::ImportValue': !Sub '${ParentPublicZoneStack}-DomainName'
 
   CertBotAutoScaleGroup:
     DependsOn:

--- a/operations/certificate-manager.yaml
+++ b/operations/certificate-manager.yaml
@@ -373,6 +373,11 @@ Outputs:
     Value: !Ref CertificateBucket
     Export:
       Name: !Sub '${AWS::StackName}-CertificateBucket'
+  CertificateBucketArn:
+    Description: The bucket arn which contains the certificates
+    Value: !GetAtt CertificateBucket.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-CertificateBucketArn'
   ACMCertificate:
     Description: The ARN of the certificate created in ACM.
     Value: !Ref ACMCertificate

--- a/operations/certificate-manager.yaml
+++ b/operations/certificate-manager.yaml
@@ -272,7 +272,7 @@ Resources:
             run_certbot:
               command: "sudo docker run --log-driver=fluentd --name certbot -v /etc/letsencrypt:/etc/letsencrypt certbot/dns-route53 certonly $LE_ENV --keep-until-expiring -n --agree-tos --rsa-key-size 4096 --email $EMAIL_ADDRESS --dns-route53 -d $CERT_DOMAIN -d *.$CERT_DOMAIN"
               env:
-               LE_ENV: { "Fn::If" : [ "CreateProdCertificates", "", "--test-cert" ] }
+               LE_ENV: { "Fn::If" : [ "CreateProdCertificates", "--server https://acme-v02.api.letsencrypt.org/directory", "--test-cert" ] }
                CERT_DOMAIN: { "Fn::ImportValue" : {"Fn::Sub": "${ParentPublicZoneStack}-DomainName" } }
                EMAIL_ADDRESS: { "Ref": "EmailAddress"}
               cwd: "~"
@@ -326,7 +326,7 @@ Resources:
         WaitOnResourceSignals: true
     Properties:
       MinSize: 0
-      MaxSize: 2
+      MaxSize: 1
       DesiredCapacity: 1
       HealthCheckType: EC2
       HealthCheckGracePeriod: 300


### PR DESCRIPTION
This pull request ensures that all external communication between major components of the infrastructure occur over TLS. The following services are now served over TLS only:
- Consul Servers
- Vault Servers
- Consul Agents
- HA Proxy

End To End TLS is now available for:
- Consul
- Vault
- HA Proxy Stats