### PR TITLE
Verify PR templates using files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ script:
 - yamllint .
 - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then find . -type f -name '*.y?ml' | while
   read file; do set -ex && aws s3 cp "$file" "s3://cf-templates-depost/$TRAVIS_PULL_REQUEST_BRANCH/$file"
-  && aws cloudformation validate-template --template-url "https://s3.amazonaws.com/cf-templates-depost/$TRAVIS_PULL_REQUEST_BRANCH/$file"
+  && aws cloudformation validate-template --template-body "file://$file"
   > /dev/null; done; fi
 - if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then
   find . -type f -name '*.y?ml' | while read file; do set -ex && aws s3 cp "$file"
   "s3://cf-templates-depost/$TRAVIS_BUILD_NUMBER/$file" && aws cloudformation validate-template
   --template-url "https://s3.amazonaws.com/cf-templates-depost/$TRAVIS_BUILD_NUMBER/$file"
   > /dev/null; done; fi
-
-after_success:
-- if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then aws s3 rm --recursive s3://cf-templates-depost/$TRAVIS_PULL_REQUEST_BRANCH;
-  fi


### PR DESCRIPTION
Instead of uploading the files to S3 when validating the PR we can do it directly using the files and only uploading files when we merge to the master branch.